### PR TITLE
setting mBarcodeView to null when camera is dismantled

### DIFF
--- a/android/src/main/java/com/dutchconcepts/capacitor/barcodescanner/BarcodeScanner.java
+++ b/android/src/main/java/com/dutchconcepts/capacitor/barcodescanner/BarcodeScanner.java
@@ -129,6 +129,7 @@ public class BarcodeScanner extends Plugin implements BarcodeCallback {
                         mBarcodeView.pause();
                         mBarcodeView.stopDecoding();
                         ((ViewGroup) bridge.getWebView().getParent()).removeView(mBarcodeView);
+                        mBarcodeView = null;
                     }
                 }
             );


### PR DESCRIPTION
Setting mBarcodeView to null when camera is dismantled to avoid for the barcode-scanner to open camera if the app is backgrounded and then foregrounded again. 
When an app is resumed Capacitor goes through all plugins to alert them that the app has been resumed, because mBarcodeView is never set to null when it is dismantled, the view attempts to open the camera when it isn't in use. This can cause issues with other plugins that need to access the camera.