### PR TITLE
android torch off, and iOS

### DIFF
--- a/android/src/main/java/com/dutchconcepts/capacitor/barcodescanner/BarcodeScanner.java
+++ b/android/src/main/java/com/dutchconcepts/capacitor/barcodescanner/BarcodeScanner.java
@@ -337,6 +337,7 @@ public class BarcodeScanner extends Plugin implements BarcodeCallback {
 
     @PluginMethod
     public void disableTorch(PluginCall call) {
+        setTorch(false);
         call.resolve();
     }
 

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -7,6 +7,8 @@ CAP_PLUGIN(BarcodeScanner, "BarcodeScanner",
     CAP_PLUGIN_METHOD(showBackground, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(startScan, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(stopScan, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(enableTorch, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(disableTorch, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(checkPermission, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(openAppSettings, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -378,10 +378,37 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
     }
 
     @objc func enableTorch(_ call: CAPPluginCall) {
+        guard 
+            let device = AVCaptureDevice.default(for: AVMediaType.video),
+            device.hasTorch
+        else { return }
+
+        do {
+            try device.lockForConfiguration()
+            device.torchMode = .on
+            device.unlockForConfiguration()
+        } catch {
+            print("Torch could not be used")
+        }
+
         call.resolve()
     }
 
     @objc func disableTorch(_ call: CAPPluginCall) {
+        // DRY I know
+        guard 
+            let device = AVCaptureDevice.default(for: AVMediaType.video),
+            device.hasTorch
+        else { return }
+
+        do {
+            try device.lockForConfiguration()
+            device.torchMode = .off
+            device.unlockForConfiguration()
+        } catch {
+            print("Torch could not be used")
+        }
+
         call.resolve()
     }
 

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -377,6 +377,14 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
         call.resolve()
     }
 
+    @objc func enableTorch(_ call: CAPPluginCall) {
+        call.resolve()
+    }
+
+    @objc func disableTorch(_ call: CAPPluginCall) {
+        call.resolve()
+    }
+
     @objc func checkPermission(_ call: CAPPluginCall) {
         let force = call.getBool("force") ?? false
 

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -378,15 +378,12 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
     }
 
     @objc func enableTorch(_ call: CAPPluginCall) {
-        // swift 5 answer from https://stackoverflow.com/questions/27207278/how-to-turn-flashlight-on-and-off-in-swift/27334447
         guard let device = AVCaptureDevice.default(for: AVMediaType.video) else { return }
         guard device.hasTorch else { print("Torch isn't available"); return }
 
         do {
             try device.lockForConfiguration()
             device.torchMode = .on
-            // Optional thing you may want when the torch it's on, is to manipulate the level of the torch
-            if on { try device.setTorchModeOn(level: AVCaptureDevice.maxAvailableTorchLevel.significand) }
             device.unlockForConfiguration()
         } catch {
             print("Torch can't be used")
@@ -395,8 +392,6 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
     }
 
     @objc func disableTorch(_ call: CAPPluginCall) {
-        // DRY I know
-        // swift 5 answer from https://stackoverflow.com/questions/27207278/how-to-turn-flashlight-on-and-off-in-swift/27334447
         guard let device = AVCaptureDevice.default(for: AVMediaType.video) else { return }
         guard device.hasTorch else { print("Torch isn't available"); return }
 

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -378,37 +378,35 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
     }
 
     @objc func enableTorch(_ call: CAPPluginCall) {
-        guard 
-            let device = AVCaptureDevice.default(for: AVMediaType.video),
-            device.hasTorch
-        else { return }
+        // swift 5 answer from https://stackoverflow.com/questions/27207278/how-to-turn-flashlight-on-and-off-in-swift/27334447
+        guard let device = AVCaptureDevice.default(for: AVMediaType.video) else { return }
+        guard device.hasTorch else { print("Torch isn't available"); return }
 
         do {
             try device.lockForConfiguration()
             device.torchMode = .on
+            // Optional thing you may want when the torch it's on, is to manipulate the level of the torch
+            if on { try device.setTorchModeOn(level: AVCaptureDevice.maxAvailableTorchLevel.significand) }
             device.unlockForConfiguration()
         } catch {
-            print("Torch could not be used")
+            print("Torch can't be used")
         }
-
         call.resolve()
     }
 
     @objc func disableTorch(_ call: CAPPluginCall) {
         // DRY I know
-        guard 
-            let device = AVCaptureDevice.default(for: AVMediaType.video),
-            device.hasTorch
-        else { return }
+        // swift 5 answer from https://stackoverflow.com/questions/27207278/how-to-turn-flashlight-on-and-off-in-swift/27334447
+        guard let device = AVCaptureDevice.default(for: AVMediaType.video) else { return }
+        guard device.hasTorch else { print("Torch isn't available"); return }
 
         do {
             try device.lockForConfiguration()
             device.torchMode = .off
             device.unlockForConfiguration()
         } catch {
-            print("Torch could not be used")
+            print("Torch can't be used")
         }
-
         call.resolve()
     }
 


### PR DESCRIPTION
Fix for:
* Turn off android torch on disableTorch()
* Implemented on/off in iOS

tested on exactly 3 iPhones and 1 android device :smile: 

sorry about the iOS code repetition, I know zip about swift but found hints on https://stackoverflow.com/questions/27207278/how-to-turn-flashlight-on-and-off-in-swift/27334447 and basically copied it over twice, once for off and once for on :+1:  Someone feel free to DRY the code by implement a setTorch(bool) in swift code too.