### PR TITLE
fix: _checkPermission is called twice when force is set to true

### DIFF
--- a/android/src/main/java/com/dutchconcepts/capacitor/barcodescanner/BarcodeScanner.java
+++ b/android/src/main/java/com/dutchconcepts/capacitor/barcodescanner/BarcodeScanner.java
@@ -474,7 +474,7 @@ public class BarcodeScanner extends Plugin implements BarcodeCallback {
 
         if (force != null && force) {
             _checkPermission(call, true);
-        }else{
+        } else {
             _checkPermission(call, false);
         }
     }

--- a/android/src/main/java/com/dutchconcepts/capacitor/barcodescanner/BarcodeScanner.java
+++ b/android/src/main/java/com/dutchconcepts/capacitor/barcodescanner/BarcodeScanner.java
@@ -474,8 +474,9 @@ public class BarcodeScanner extends Plugin implements BarcodeCallback {
 
         if (force != null && force) {
             _checkPermission(call, true);
+        }else{
+            _checkPermission(call, false);
         }
-        _checkPermission(call, false);
     }
 
     @PluginMethod


### PR DESCRIPTION
Finally found the cause of issue #71 .

_checkPermission was called twice when force is set to true, and the second call resolves the plugin call before the user has responded to the permission request.

It can be installed and tested like this:
`npm i git+https://github.com/ec-lmayr/barcode-scanner.git#fix/build-on-install`
That second PR (83) includes the _checkPermission fix as well as a change that the plugin is built when installed from github directly.
you can see that PR here: https://github.com/capacitor-community/barcode-scanner/pull/83

closes #71