### PR TITLE
fix: build on install

### DIFF
--- a/android/src/main/java/com/dutchconcepts/capacitor/barcodescanner/BarcodeScanner.java
+++ b/android/src/main/java/com/dutchconcepts/capacitor/barcodescanner/BarcodeScanner.java
@@ -474,7 +474,7 @@ public class BarcodeScanner extends Plugin implements BarcodeCallback {
 
         if (force != null && force) {
             _checkPermission(call, true);
-        }else{
+        } else {
             _checkPermission(call, false);
         }
     }

--- a/android/src/main/java/com/dutchconcepts/capacitor/barcodescanner/BarcodeScanner.java
+++ b/android/src/main/java/com/dutchconcepts/capacitor/barcodescanner/BarcodeScanner.java
@@ -474,8 +474,9 @@ public class BarcodeScanner extends Plugin implements BarcodeCallback {
 
         if (force != null && force) {
             _checkPermission(call, true);
+        }else{
+            _checkPermission(call, false);
         }
-        _checkPermission(call, false);
     }
 
     @PluginMethod

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build": "npm run clean && tsc && rollup -c rollup.config.js",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "prepublishOnly": "npm run build"
+    "prepare": "npm run build"
   },
   "devDependencies": {
     "@capacitor/android": "^3.0.0",


### PR DESCRIPTION
Use "prepare" instead of "prepublishOnly" to make sure the plugin is also built when installed directly from github.

This includes the changes in PR https://github.com/capacitor-community/barcode-scanner/pull/82 , so that users can install the fix from this branch directly from github. 