### PR TITLE
Allow choosing front or back camera

### DIFF
--- a/android/src/main/java/com/dutchconcepts/capacitor/barcodescanner/BarcodeScanner.java
+++ b/android/src/main/java/com/dutchconcepts/capacitor/barcodescanner/BarcodeScanner.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
+//import android.graphics.Camera;
 import android.hardware.Camera;
 import android.net.Uri;
 import android.os.Build;
@@ -48,7 +49,7 @@ public class BarcodeScanner extends Plugin implements BarcodeCallback {
 
     private BarcodeView mBarcodeView;
 
-    private int currentCameraId = Camera.CameraInfo.CAMERA_FACING_BACK;
+    //private int currentCameraId = Camera.CameraInfo.CAMERA_FACING_BACK;
 
     private boolean isScanning = false;
     private boolean shouldRunScan = false;
@@ -93,7 +94,7 @@ public class BarcodeScanner extends Plugin implements BarcodeCallback {
         }
     }
 
-    private void setupCamera() {
+    private void setupCamera(String cameraDirection) {
         // @TODO(): add support for switching cameras
         // @TODO(): add support for toggling torch
 
@@ -105,7 +106,9 @@ public class BarcodeScanner extends Plugin implements BarcodeCallback {
 
                     // Configure the camera (front/back)
                     CameraSettings settings = new CameraSettings();
-                    settings.setRequestedCameraId(currentCameraId);
+                    settings.setRequestedCameraId(
+                        "front".equals(cameraDirection) ? Camera.CameraInfo.CAMERA_FACING_FRONT : Camera.CameraInfo.CAMERA_FACING_BACK
+                    );
                     settings.setContinuousFocusEnabled(true);
                     mBarcodeView.setCameraSettings(settings);
 
@@ -153,13 +156,13 @@ public class BarcodeScanner extends Plugin implements BarcodeCallback {
         }
     }
 
-    private void prepare() {
+    private void _prepare(PluginCall call) {
         // undo previous setup
         // because it may be prepared with a different config
         dismantleCamera();
 
         // setup camera with new config
-        setupCamera();
+        setupCamera(call.getString("cameraDirection", "back"));
 
         // indicate this method was run
         didRunCameraPrepare = true;
@@ -225,7 +228,7 @@ public class BarcodeScanner extends Plugin implements BarcodeCallback {
                     Log.d("scanner", "No permission to use camera. Did you request it yet?");
                 } else {
                     shouldRunScan = true;
-                    prepare();
+                    _prepare(getSavedCall());
                 }
             }
         } else {
@@ -310,7 +313,7 @@ public class BarcodeScanner extends Plugin implements BarcodeCallback {
 
     @PluginMethod
     public void prepare(PluginCall call) {
-        prepare();
+        _prepare(call);
         call.resolve();
     }
 
@@ -476,7 +479,7 @@ public class BarcodeScanner extends Plugin implements BarcodeCallback {
             _checkPermission(call, true);
         } else {
             _checkPermission(call, false);
-        }   
+        }
     }
 
     @PluginMethod

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -133,7 +133,7 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
         return false;
     }
 
-    private func setupCamera(cameraDirection: String = "back") -> Bool {
+    private func setupCamera(cameraDirection: String? = "back") -> Bool {
         do {
             var cameraDir = cameraDirection
             cameraView.backgroundColor = UIColor.clear
@@ -184,13 +184,13 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
     @available(swift, deprecated: 5.6, message: "New Xcode? Check if `AVCaptureDevice.DeviceType` has new types and add them accordingly.")
     private func discoverCaptureDevices() -> [AVCaptureDevice] {
         if #available(iOS 13.0, *) {
-            return AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInTripleCamera, .builtInDualCamera, .builtInDualWideCamera, .builtInWideAngleCamera, .builtInUltraWideCamera, .builtInTelephotoCamera, .builtInTrueDepthCamera], mediaType: .video, position: .front).devices
+            return AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInTripleCamera, .builtInDualCamera, .builtInTelephotoCamera, .builtInTrueDepthCamera, .builtInUltraWideCamera, .builtInDualWideCamera, .builtInWideAngleCamera], mediaType: .video, position: .unspecified).devices
         } else {
-            return AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInDualCamera, .builtInWideAngleCamera, .builtInTelephotoCamera, .builtInTrueDepthCamera], mediaType: .video, position: .front).devices
+            return AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInDualCamera, .builtInWideAngleCamera, .builtInTelephotoCamera, .builtInTrueDepthCamera], mediaType: .video, position: .unspecified).devices
         }
     }
 
-    private func createCaptureDeviceInput(cameraDirection: String = "back") throws -> AVCaptureDeviceInput {
+    private func createCaptureDeviceInput(cameraDirection: String? = "back") throws -> AVCaptureDeviceInput {
         var captureDevice: AVCaptureDevice
         if(cameraDirection == "back"){
             if(backCamera != nil){
@@ -247,7 +247,7 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
 
         DispatchQueue.main.async {
             // setup camera with new config
-            if (self.setupCamera(cameraDirection: call?.options["cameraDirection"])) {
+            if (self.setupCamera(cameraDirection: call?.getString("cameraDirection") ?? "back")) {
                 // indicate this method was run
                 self.didRunCameraPrepare = true
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,5 +1,5 @@
 export interface BarcodeScannerPlugin {
-  prepare(): Promise<void>;
+  prepare(options?: ScanOptions): Promise<void>;
   hideBackground(): Promise<void>;
   showBackground(): Promise<void>;
   startScan(options?: ScanOptions): Promise<ScanResult>;
@@ -80,6 +80,10 @@ export enum SupportedFormat {
   // END 2D
 }
 
+export enum CameraDirection {
+  FRONT = 'front',
+  BACK = 'back',
+}
 export interface ScanOptions {
   /**
    * This parameter can be used to make the scanner only recognize specific types of barcodes.
@@ -88,6 +92,7 @@ export interface ScanOptions {
    * @since 1.2.0
    */
   targetedFormats?: SupportedFormat[];
+  cameraDirection?: CameraDirection;
 }
 
 export interface StopScanOptions {


### PR DESCRIPTION
In `prepare` or `startScan` allow providing a value `"front"` or `"back"` to `cameraDirection` option. 

Does _not_ allow switching camera during a scanning session.