### PR TITLE
update: Reset lastScanResult on resumeScanning

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/barcodescanner/BarcodeScanner.java
+++ b/android/src/main/java/com/getcapacitor/community/barcodescanner/BarcodeScanner.java
@@ -385,6 +385,7 @@ public class BarcodeScanner extends Plugin implements BarcodeCallback {
 
     @PluginMethod
     public void resumeScanning(PluginCall call) {
+        lastScanResult = null; // reset when scanning again
         scanningPaused = false;
         call.resolve();
     }


### PR DESCRIPTION
I want to scan several barcodes in a row including two same barcodes in a row. But the plugin prevents to scan twice the same barcode. 
Removing this condition creates more problems than anything else, returns the value many times and there is no notion of scan frequency to remedy this.
So for my need I decide to pause the scan and by user interaction to resume it. This way the scan is always open and I can scan several barcodes including several times the same one and the user controls what he scans