### PR TITLE
Reset last scanned code when resuming scan

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/barcodescanner/BarcodeScanner.java
+++ b/android/src/main/java/com/getcapacitor/community/barcodescanner/BarcodeScanner.java
@@ -385,6 +385,7 @@ public class BarcodeScanner extends Plugin implements BarcodeCallback {
 
     @PluginMethod
     public void resumeScanning(PluginCall call) {
+        lastScanResult = null; // reset when scanning again
         scanningPaused = false;
         call.resolve();
     }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -449,6 +449,7 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
     }
 
     @objc func resumeScanning(_ call: CAPPluginCall) {
+       lastScanResult = nil
         scanningPaused = false
         call.resolve()
     }


### PR DESCRIPTION
This is a fork where the last scanned code is resetted when resumeScan() is called. 
So you can scan the same code again when you resume scanning.
It's working on iOS and Android in my case.

Feel free to test, especially when using the startScan()-function.