### PR TITLE
fix IOS orientation

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -277,6 +277,7 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
                 // @TODO()
                 // requestPermission()
             } else {
+                self.load();
                 self.shouldRunScan = true
                 self.prepare(savedCall)
             }


### PR DESCRIPTION
Steps to reproduce :
open the app in portrait/landscape mode => rotate => open the camera 

Issue
the CameraView was being loaded when the app starts not with each scan.

Somehow the cameraView doesn't recognize that the app has rotated