### PR TITLE
fix(ios): added self. to savedCall in scan()

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -280,7 +280,7 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
                 DispatchQueue.main.async {
                     self.load();
                     self.shouldRunScan = true
-                    self.prepare(savedCall)
+                    self.prepare(self.savedCall)
                 } 
             }
         } else {


### PR DESCRIPTION
After tyring to build it Xcode failed because of missing reference:
<img width="959" alt="Képernyőfotó 2022-08-09 - 22 30 37" src="https://user-images.githubusercontent.com/1770194/183758042-40013c68-416c-4680-be01-c428a3cc4d1b.png">

Fixed it, and it is working properly on iOS, with Ionic Angular:
❯ npx cap doctor
💊   Capacitor Doctor  💊

Latest Dependencies:

  @capacitor/cli: 4.0.1
  @capacitor/core: 4.0.1
  @capacitor/android: 4.0.1
  @capacitor/ios: 4.0.1

Installed Dependencies:

  @capacitor/cli: 4.0.1
  @capacitor/core: 4.0.1
  @capacitor/android: 4.0.1
  @capacitor/ios: 4.0.1

[success] iOS looking great! 👌

