### PR TITLE
Fix bg color Dark mode iOS

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -141,7 +141,7 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
             var cameraDir = cameraDirection
             cameraView.backgroundColor = UIColor.clear
             self.webView!.superview!.insertSubview(cameraView, belowSubview: self.webView!)
-            
+
             let availableVideoDevices =  discoverCaptureDevices()
             for device in availableVideoDevices {
                 if device.position == AVCaptureDevice.Position.back {
@@ -281,7 +281,7 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
                     self.load();
                     self.shouldRunScan = true
                     self.prepare(self.savedCall)
-                } 
+                }
             }
         } else {
             self.didRunCameraPrepare = false
@@ -330,7 +330,7 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
             self.bridge?.webView!.backgroundColor = UIColor.clear
             self.bridge?.webView!.scrollView.backgroundColor = UIColor.clear
 
-            let javascript = "document.documentElement.style.backgroundColor = 'transparent'"
+            let javascript = "document.documentElement.style.backgroundColor = 'transparent';document.body.style.backgroundColor = 'transparent'"
 
             self.bridge?.webView!.evaluateJavaScript(javascript)
         }
@@ -338,7 +338,7 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
 
     private func showBackground() {
         DispatchQueue.main.async {
-            let javascript = "document.documentElement.style.backgroundColor = ''"
+            let javascript = "document.documentElement.style.backgroundColor = '';document.body.style.backgroundColor = ''"
 
             self.bridge?.webView!.evaluateJavaScript(javascript) { (result, error) in
                 self.bridge?.webView!.isOpaque = true


### PR DESCRIPTION

Hi (sry for my bad English),

I update my project with ionic 6/ capacitor v4, and got problem with iOS in dark mode (iPhone 13), don't show the camera preview for scan. I think it's same issue to #118.

I just edit the iOS Plugin to add transparent bg in body html tag. Ionic add dark background in the body (--ion-background-color) and override the background transparent in html tag. Don't know if just me got the problem, but I resolve like this.

In Android get same issue but not in dark mode, the camera not show.

I resolve like this and follow tutorial in post #118:

1. add `<div class="scan-box" [hidden]="!scanActive"></div>` in .html ionic page (not in ion-content for full preview)

2. CSS of scan-box
```css
.scan-box {
	border: 2px solid #fff;
	box-shadow: 0 0 0 100vmax rgb(0, 0, 0, 0.5);
	content: "";
	display: block;
	left: 50%;
	height: 300px;
	position: absolute;
	top: 50%;
	transform: translate(-50%, -50%);
	width: 300px;
	visibility: visible;
}

```
3. add `[hidden]="scanActive" `ion <ion-content>, <ion-header> and <ion-footer> if present (scanActive dynamic in home.page.ts for example)

So when I click a button for start scan for example, scanActive is set to true, and hide <ion-content>, <ion-header>, <ion-footer> and add transparent bg in html/body tag and show the camera.

Now I can scan easy ^^

![IMG_058BDEC3DDCA-1](https://user-images.githubusercontent.com/16757083/184299139-f69c9e02-2168-45b9-b49f-e76853597a22.jpeg)

