### PR TITLE
iOS interface orientation obsolete

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -30,8 +30,10 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
                     layer.frame = self.bounds
                 }
             }
-
-            self.videoPreviewLayer?.connection?.videoOrientation = interfaceOrientationToVideoOrientation(UIApplication.shared.statusBarOrientation)
+            
+            if let interfaceOrientation = UIApplication.shared.windows.first(where: { $0.isKeyWindow })?.windowScene?.interfaceOrientation {
+                self.videoPreviewLayer?.connection?.videoOrientation = interfaceOrientationToVideoOrientation(interfaceOrientation)
+            }
         }
 
 


### PR DESCRIPTION
On iOS the `UIApplication.shared.statusBarOrientation` is deprecated and on newer versions obsolete. It has been replaced by code suggested here:
https://askcodes.net/coding/-statusbarorientation--was-deprecated-in-ios-13-0-when-attempting-to-get-app-orientation

https://github.com/capacitor-community/barcode-scanner/issues/129