### PR TITLE
Better handling of binary QRs with payload not encodable as text

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/barcodescanner/BarcodeScanner.java
+++ b/android/src/main/java/com/getcapacitor/community/barcodescanner/BarcodeScanner.java
@@ -293,14 +293,6 @@ public class BarcodeScanner extends Plugin implements BarcodeCallback {
     }
 
     private boolean isPrintableString(byte[] bytes) {
-        /*        for (int i = 0; i < bytes.length; i++) {
-            byte val = bytes[i];
-            if (val <= 32 || val >= 127) {
-                return false;
-            }
-        }
-        return true;*/
-
         CharsetDecoder decoder = Charset.forName("UTF-8").newDecoder();
         ByteBuffer buf = ByteBuffer.wrap(bytes);
 

--- a/android/src/main/java/com/getcapacitor/community/barcodescanner/BarcodeScanner.java
+++ b/android/src/main/java/com/getcapacitor/community/barcodescanner/BarcodeScanner.java
@@ -304,6 +304,11 @@ public class BarcodeScanner extends Plugin implements BarcodeCallback {
 
         String resString = "";
 
+        //debug
+        byte[] raw = barcodeResult.getRawBytes();
+        String rawAsString = Base64.getEncoder().encodeToString(raw);
+        Log.d("scanner", rawAsString);
+
         //BYTE_SEGMENT[0] contains the decoded bytes from the qr.
         Map<ResultMetadataType, Object> md = barcodeResult.getResultMetadata();
         Object res = md.get(ResultMetadataType.BYTE_SEGMENTS);

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -422,7 +422,7 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
             if (found.type == AVMetadataObject.ObjectType.qr){
                 let qrCodeDescriptor = found.descriptor as? CIQRCodeDescriptor
                 
-                // if string value is nil, either there is nothing there, or its bytes
+                // if string value is nil, either there is nothing there, or it was not encoded correctly
                 if (found.stringValue == nil) {
                     if let rawBytes = qrCodeDescriptor?.errorCorrectedPayload {
                         //raw bytes needs to be processed to get the actual qr code message
@@ -779,14 +779,14 @@ enum Mode: Int {
     case endOfMessage         = 0 // 0000 終端パターン
     var description: String {
         switch self {
-        case .numeric:              return "0001 数字"
-        case .alphanumeric:         return "0010 英数字"
+        case .numeric:              return "0001 numeric"
+        case .alphanumeric:         return "0010 alphanumeric"
         case .byte:                 return "0100 byte"
-        case .kanji:                return "1000 漢字"
-        case .structuredAppend:     return "0011 構造的連接"
+        case .kanji:                return "1000 kanji"
+        case .structuredAppend:     return "0011 structuredAppend"
         case .eci:                  return "0111 ECI"
-        case .fnc1InFirstPosition:  return "0101 FNC1（1番目の位置）"
-        case .fnc1InSecondPosition: return "1001 FNC1（1番目の位置）"
+        case .fnc1InFirstPosition:  return "0101 FNC1 1st pos"
+        case .fnc1InSecondPosition: return "1001 FNC1 2nd pos"
         case .endOfMessage:         return "0000 end of message"
         }
     }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -1,7 +1,6 @@
 import Capacitor
 import Foundation
 import AVFoundation
-import OSLog
 
 @objc(BarcodeScanner)
 public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
@@ -195,18 +194,6 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
     }
 
     private func createCaptureDeviceInput(cameraDirection: String? = "back") throws -> AVCaptureDeviceInput {
-        if #available(OSX 11.0, *) {
-            if #available(iOS 14.0, *) {
-                let customLog = Logger(subsystem: "technology.truevolve.scrutineer",
-                                       category: "scanner log")
-                customLog.debug("Using custom code!")
-            } else {
-                // Fallback on earlier versions
-            }
-            
-        }
-
-
         var captureDevice: AVCaptureDevice
         if(cameraDirection == "back"){
             if(backCamera != nil){


### PR DESCRIPTION
Addresses issue #148.

In cases where a binary QR was scanned and the underlying libs were not able to encode the payload as text; get the byte payload as encode as base64.