### PR TITLE
ios fix: move Optional nil check to prevent unwrapping error

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -222,8 +222,8 @@ public class BarcodeScanner: CAPPlugin, AVCaptureMetadataOutputObjectsDelegate {
     private func dismantleCamera() {
         // opposite of setupCamera
 
-        if (self.captureSession != nil) {
-            DispatchQueue.main.async {
+        DispatchQueue.main.async {
+            if (self.captureSession != nil) {
                 self.captureSession!.stopRunning()
                 self.cameraView.removePreviewLayer()
                 self.captureVideoPreviewLayer = nil


### PR DESCRIPTION
Hi @thegnuu. First of all, thanks for your work on this super helpful plugin! I really appreciate all the effort you (and other maintainers) put into this.
I recently updated the plugin to make it work with XCode 14 and Capacitor 4 and after running my tests I found that the app was crashing after closing the BarcodeScanner instance. After looking into it I realized that a small change in the swift code would solve the issue. I'm not an expert Swift developer so I might have missed something else, but after the fix the plugin seems to work as expected. Any feedback would be really appreciated.

This small fix moves the Optional nil check inside `DispatchQueue` to prevent an unwrapping error on `stopScan()` that crashes the app using this plugin.