### PR TITLE
Make `ScanResult` a union type instead of an interface

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -124,7 +124,7 @@ export interface StopScanOptions {
   resolveScan?: boolean;
 }
 
-export interface ScanResult {
+export type ScanResult {
   /**
    * This indicates whether or not the scan resulted in readable content.
    * When stopping the scan with `resolveScan` set to `true`, for example,
@@ -132,21 +132,44 @@ export interface ScanResult {
    *
    * @since 1.0.0
    */
-  hasContent: boolean;
+  hasContent: true;
 
   /**
    * This holds the content of the barcode if available.
    *
    * @since 1.0.0
    */
-  content?: string;
+  content: string;
 
   /**
    * This returns format of scan result.
    *
    * @since 2.1.0
    */
-  format?: string;
+  format: string;
+} | { 
+  /**
+   * This indicates whether or not the scan resulted in readable content.
+   * When stopping the scan with `resolveScan` set to `true`, for example,
+   * this parameter is set to `false`, because no actual content was scanned.
+   *
+   * @since 1.0.0
+   */
+  hasContent: false;
+
+  /**
+   * This holds the content of the barcode if available.
+   *
+   * @since 1.0.0
+   */
+  content: undefined;
+
+  /**
+   * This returns format of scan result.
+   *
+   * @since 2.1.0
+   */
+  format: undefined;
 }
 
 export interface CheckPermissionOptions {


### PR DESCRIPTION
This should greatly improve the type inference when checking the result with `result.hasContent`. Right now, TypeScript has no idea that if `hasContent` is true, that implies something about the type of `result.content`, but this PR gives it that context.

(Do let me know if this is made impossible by iOS/Android platform limitations, I'm just making this since I ran into this in my project.)