### PR TITLE
Urgent fix since I forgot the `=` sign when declaring the `ScanResult` type

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -124,7 +124,7 @@ export interface StopScanOptions {
   resolveScan?: boolean;
 }
 
-export type ScanResult {
+export type ScanResult = {
   /**
    * This indicates whether or not the scan resulted in readable content.
    * When stopping the scan with `resolveScan` set to `true`, for example,


### PR DESCRIPTION
oops, sorry!