### PR TITLE
[iOS] Mark the start() callback as keepAlive

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/barcodescanner/CapacitorCommunityBarcodeScanner.java
+++ b/android/src/main/java/com/getcapacitor/community/barcodescanner/CapacitorCommunityBarcodeScanner.java
@@ -305,6 +305,9 @@ public class CapacitorCommunityBarcodeScanner extends Plugin implements ImageAna
                         @RequiresApi(api = Build.VERSION_CODES.O)
                         @Override
                         public void onSuccess(List<Barcode> barcodes) {
+                            if (scanningPaused) {
+                                return;
+                            }
                             for (Barcode barcode : barcodes) {
                                 PluginCall call = getSavedCall();
 

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -413,25 +413,25 @@ public class CapacitorCommunityBarcodeScanner: CAPPlugin, AVCaptureVideoDataOutp
     public func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
  
         switch UIDevice.current.orientation {
-            case .portrait:
-                print("portrait")
-                connection.videoOrientation = AVCaptureVideoOrientation.portrait
-                break
-            case .portraitUpsideDown:
-                print("portraitUpsideDown")
-                connection.videoOrientation = AVCaptureVideoOrientation.portraitUpsideDown
-                break
-            case .landscapeLeft:
-                print("landscapeLeft")
-                connection.videoOrientation = AVCaptureVideoOrientation.landscapeLeft
-                break
-            case .landscapeRight:
-                print("landscapeRight")
-                connection.videoOrientation = AVCaptureVideoOrientation.landscapeRight
-                break
-            default:
-                print("do not set this")
-                // connection.videoOrientation = AVCaptureVideoOrientation.portrait
+        case .portrait,.unknown,.faceUp:
+            // print("portrait")
+            connection.videoOrientation = AVCaptureVideoOrientation.portrait
+            break
+        case .portraitUpsideDown,.faceDown:
+            // print("portraitUpsideDown")
+            connection.videoOrientation = AVCaptureVideoOrientation.portraitUpsideDown
+            break
+        case .landscapeLeft:
+            // print("landscapeLeft")
+            connection.videoOrientation = AVCaptureVideoOrientation.landscapeLeft
+            break
+        case .landscapeRight:
+            // print("landscapeRight")
+            connection.videoOrientation = AVCaptureVideoOrientation.landscapeRight
+            break
+        default:
+            // print("do not set this")
+            connection.videoOrientation = AVCaptureVideoOrientation.portrait            
         }
         
         if let barcodeScanner = self.barcodeScanner {
@@ -473,6 +473,7 @@ public class CapacitorCommunityBarcodeScanner: CAPPlugin, AVCaptureVideoDataOutp
 
     @objc func start(_ call: CAPPluginCall) {
         self.savedCall = call
+        call.keepAlive = true;
         scanningPaused = false
         self.scan()
     }


### PR DESCRIPTION
The callback handed to `start()` was not marked as `keepAlive`, hence after providing one result it was discarded. This PR fixes that. Also updated a switch statement to be exhaustive.