### PR TITLE
[ML-Kit] set and get camera zoom (iOS only for now)

### DIFF
--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -14,4 +14,6 @@ CAP_PLUGIN(CapacitorCommunityBarcodeScanner, "CapacitorCommunityBarcodeScanner",
     CAP_PLUGIN_METHOD(toggleTorch, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(getTorchState, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(vibrate, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(getZoomState, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(setZoom, CAPPluginReturnPromise);
 )

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,4 +1,3 @@
-
 import type { PermissionState } from '@capacitor/core';
 
 export type CameraPermissionState = PermissionState | 'limited';
@@ -14,7 +13,6 @@ export interface PermissionStates {
 export interface CameraPluginPermissions {
   permissions: CameraPermissionType[];
 }
-
 
 export interface BarcodeScannerPlugin {
   // TODO: I am not sure if this will make sense anymore in the ML Kit version
@@ -106,6 +104,21 @@ export interface BarcodeScannerPlugin {
    * @since 4.0.0
    */
   vibrate(): Promise<void>;
+
+  /**
+   * Get current zoom, min and max zoom,
+   * and if available the factors that trigger switching to another camera
+   *
+   * @since 4.0.0
+   */
+  getZoomState(): Promise<ZoomStateResult>;
+
+  /**
+   * Set the zoom
+   *
+   * @since 4.0.0
+   */
+  setZoom(zoomOptions: ZoomOptions): Promise<ZoomStateResult>;
 }
 
 export type CallbackID = string;
@@ -147,6 +160,8 @@ export interface ScanOptions {
    * @since 4.0.0
    */
   cameraDirection?: CameraDirection;
+
+  zoom?: number;
 }
 
 export interface ScanResult {
@@ -186,4 +201,19 @@ export interface TorchStateResult {
    * @since 3.0.0
    */
   isEnabled: boolean;
+}
+
+export interface ZoomStateResult {
+  /**
+   * Current zoom
+   */
+  zoom: number;
+
+  minimum: number;
+  maximum: number;
+  switchOver?: number[];
+}
+
+export interface ZoomOptions {
+  zoom: number;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,7 +1,15 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { WebPlugin } from '@capacitor/core';
 
-import type { BarcodeScannerPlugin, PermissionStates, ScanOptions, ScanResult, TorchStateResult } from './definitions';
+import type {
+  BarcodeScannerPlugin,
+  PermissionStates,
+  ScanOptions,
+  ScanResult,
+  TorchStateResult,
+  ZoomOptions,
+  ZoomStateResult,
+} from './definitions';
 
 export class BarcodeScannerWeb extends WebPlugin implements BarcodeScannerPlugin {
   async start(_options: ScanOptions, _callback: (result: ScanResult, err?: any) => void): Promise<string> {
@@ -45,6 +53,14 @@ export class BarcodeScannerWeb extends WebPlugin implements BarcodeScannerPlugin
   }
 
   async vibrate(): Promise<void> {
+    throw this.unimplemented('Not implemented on web.');
+  }
+
+  async getZoomState(): Promise<ZoomStateResult> {
+    throw this.unimplemented('Not implemented on web.');
+  }
+
+  async setZoom(_zoomOptions: ZoomOptions): Promise<ZoomStateResult> {
     throw this.unimplemented('Not implemented on web.');
   }
 }


### PR DESCRIPTION
Added:
- An optional zoom parameter in `start(options)`, if provided the camera zooms to that factor.
- `getZoomState()` method, it returns current `zoom`, `minimum` and `maximum` as well as a `switchOver` which indicates at which zoom levels the camera will switch.
- `setZoom({zoom: number})` method, to set the camera zoom.

