### PR TITLE
[ML-Kit] [Android] Bugfix: don't crash when no camera

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/barcodescanner/CapacitorCommunityBarcodeScanner.java
+++ b/android/src/main/java/com/getcapacitor/community/barcodescanner/CapacitorCommunityBarcodeScanner.java
@@ -172,7 +172,11 @@ public class CapacitorCommunityBarcodeScanner extends Plugin implements ImageAna
 
                 imageAnalysis.setAnalyzer(ContextCompat.getMainExecutor(getContext()), this);
 
-                mCamera = cameraProvider.bindToLifecycle((LifecycleOwner) getContext(), cameraSelector, preview, imageAnalysis);
+                try {
+                    mCamera = cameraProvider.bindToLifecycle((LifecycleOwner) getContext(), cameraSelector, preview, imageAnalysis);
+                } catch (Exception ex) {
+                    Log.d("scanner", "Error getting camera: " + ex.getMessage());
+                }
             });
     }
 

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -308,7 +308,9 @@ public class CapacitorCommunityBarcodeScanner: CAPPlugin, AVCaptureVideoDataOutp
                 } 
             }
         } else {
-            self.didRunCameraPrepare = false
+            // JanM: this caused a crash when calling start on an already started camera
+            // also doesn't seem to make sense to force prepare to run twice?
+            // self.didRunCameraPrepare = false
 
             self.shouldRunScan = false
 


### PR DESCRIPTION
Certain devices might not have a camera, or not a camera facing the right direction. 
This would cause a big crash, because the resulting IllegalArgumentException wasn't caught.

This (quick) fix catches that exception, so at least the app won't crash. In a future it would be nice to have a some kind of `getCameraInfo` call that return the available options (camera direction, zoom, etc).