### PR TITLE
implement stopScan: resolveScan option for web

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -136,7 +136,7 @@ export interface IScanResultWithContent {
    *
    * @since 1.0.0
    */
-  hasContent: true;
+  hasContent: boolean;
 
   /**
    * This holds the content of the barcode if available.

--- a/src/web.ts
+++ b/src/web.ts
@@ -186,7 +186,7 @@ export class BarcodeScannerWeb extends WebPlugin implements BarcodeScannerPlugin
             hasContent: false,
             content: '',
             format: ''
-          })
+          });
         }
       }
     });

--- a/src/web.ts
+++ b/src/web.ts
@@ -21,6 +21,7 @@ export class BarcodeScannerWeb extends WebPlugin implements BarcodeScannerPlugin
   private _video: HTMLVideoElement | null = null;
   private _options: ScanOptions | null = null;
   private _backgroundColor: string | null = null;
+  private _resolveScanFn: any;
 
   async prepare(): Promise<void> {
     await this._getVideoElement();
@@ -78,6 +79,10 @@ export class BarcodeScannerWeb extends WebPlugin implements BarcodeScannerPlugin
       this._controls.stop();
       this._controls = null;
     }
+    if (_options?.resolveScan && this._resolveScanFn) {
+      this._resolveScanFn();
+    }
+    this._resolveScanFn = null;
   }
 
   async checkPermission(_options: CheckPermissionOptions): Promise<CheckPermissionResult> {
@@ -170,11 +175,19 @@ export class BarcodeScannerWeb extends WebPlugin implements BarcodeScannerPlugin
             controls.stop();
             this._controls = null;
             this._stop();
+            this._resolveScanFn = null;
           }
           if (error && error.message) {
             console.error(error.message);
           }
         });
+        this._resolveScanFn = () => {
+          resolve({
+            hasContent: false,
+            content: '',
+            format: ''
+          })
+        }
       }
     });
   }


### PR DESCRIPTION
the web implementation lacks the resolveScan option, which is quite handy if you implement your own UI controls.
this PR provides a very simple implementation for it. I had to change the definitions.ts so that hasContent can also be false.