### PR TITLE
Add option to place the preview video in an existing parent element

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -112,6 +112,12 @@ export interface ScanOptions {
    * @since 2.1.0
    */
   cameraDirection?: CameraDirection;
+  /**
+   * This parameter can be used to embed the camera preview in a custom parent (web only).
+   * If specified, the preview will be appended to an element with an ID of `previewParent`.
+   * Otherwise, a new div element will be appended to the document body.
+   */
+  previewParent?: string;
 }
 
 export interface StopScanOptions {

--- a/src/web.ts
+++ b/src/web.ts
@@ -185,6 +185,26 @@ export class BarcodeScannerWeb extends WebPlugin implements BarcodeScannerPlugin
     });
   }
 
+  private _getParentElement() {
+    // If a parent ID is specified, and the element exists, use it.
+    if (this._options?.previewParent) {
+      const existingParent = document.getElementById(this._options.previewParent);
+      if (existingParent) {
+        return existingParent;
+      }
+    }
+
+    // If no existing element, create a new full-page div and attach to body.
+    const body = document.body;
+    const defaultParent = document.createElement('div');
+    defaultParent.setAttribute(
+      'style',
+      'position:absolute; top: 0; left: 0; width:100%; height: 100%; background-color: black;'
+    );
+    body.appendChild(defaultParent);
+    return defaultParent;
+  }
+
   private async _startVideo(): Promise<{}> {
     return new Promise(async (resolve, reject) => {
       await navigator.mediaDevices
@@ -200,15 +220,10 @@ export class BarcodeScannerWeb extends WebPlugin implements BarcodeScannerPlugin
           reject(error);
         });
 
-      const body = document.body;
       const video = document.getElementById('video');
 
       if (!video) {
-        const parent = document.createElement('div');
-        parent.setAttribute(
-          'style',
-          'position:absolute; top: 0; left: 0; width:100%; height: 100%; background-color: black;'
-        );
+        const parent = this._getParentElement();
         this._video = document.createElement('video');
         this._video.id = 'video';
         // Don't flip video feed if camera is rear facing
@@ -234,7 +249,6 @@ export class BarcodeScannerWeb extends WebPlugin implements BarcodeScannerPlugin
         }
 
         parent.appendChild(this._video);
-        body.appendChild(parent);
 
         if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
           const constraints: MediaStreamConstraints = {


### PR DESCRIPTION
Not sure what the future of the web version is, but this adds an optional configuration setting to give more control over placement of the video preview element.
If not set, current behaviour is preserved.