### PR TITLE
PR to resolve issue #259, camera request on firefox

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -117,7 +117,16 @@ export class BarcodeScannerWeb extends WebPlugin implements BarcodeScannerPlugin
         unknown: true,
       };
     } catch {
-      throw this.unavailable('Camera permissions are not available in this browser');
+      try {
+        await navigator.mediaDevices.getUserMedia({video: true});
+        return { granted: true };
+      } catch (err) {
+        if ( (err as DOMException).name === 'NotAllowedError') {
+          return { denied: true };
+        } else {
+          throw this.unavailable('Camera permissions are not available in this browser');
+        }
+      }
     }
   }
 


### PR DESCRIPTION
if the permission query throws, like on firefox, try with `mediaDevices.getUserMedia`. this works on firefox nicely. see issue #259